### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -1,4 +1,7 @@
 name: Container
+permissions:
+  contents: read
+  packages: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/eumel8/storagecheck/security/code-scanning/7](https://github.com/eumel8/storagecheck/security/code-scanning/7)

To fix this issue, we need to add an explicit `permissions` block to the workflow YAML to restrict the GITHUB_TOKEN's permissions to the minimum necessary. In this workflow, the only actions requiring authentication are logging into the GitHub Container Registry and pushing Docker images, which require `packages: write` permission but do not require broader write access to code contents or other resources. Thus, we should set `contents: read` (the minimal default) and `packages: write` permissions.

The best way to implement this fix is to add a `permissions:` block at the appropriate scope, either at the workflow root (recommended if only one job and all jobs need the same permissions) or within the `build` job (if you plan to have jobs with different permissions). Here, adding it at the root immediately below the `name:` declaration (before `on: ...`) is the most maintainable approach.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
