### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,4 +1,6 @@
 name: "Go Coverage"
+permissions:
+  contents: write
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/eumel8/storagecheck/security/code-scanning/6](https://github.com/eumel8/storagecheck/security/code-scanning/6)

To fix this problem, an explicit `permissions` block should be added to the workflow to restrict the `GITHUB_TOKEN` permissions to the absolute minimum necessary. Because the job pushes updates to the repository (committing updated coverage badges to the README), it requires `contents: write`. The best way is to add a `permissions` block at the workflow root (just below `name` or `on`), assigning `contents: write`. This will apply to all jobs (currently just `test`). No other permissions appear to be required for this workflow.

**Location to change:** Insert the following YAML snippet after the `name: "Go Coverage"` line (line 1):

```yaml
permissions:
  contents: write
```

No other changes, definitions, or imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
