### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -1,4 +1,7 @@
 name: Helm
+permissions:
+  contents: read
+  packages: write
 
 on: 
   push: 


### PR DESCRIPTION
Potential fix for [https://github.com/eumel8/storagecheck/security/code-scanning/5](https://github.com/eumel8/storagecheck/security/code-scanning/5)

To fix this issue, you should explicitly add a `permissions` block to the workflow (either globally under the workflow root or under the relevant job). Since the workflow checks out code and pushes packaged Helm charts to the GitHub Container Registry, it requires `contents: read` to read the repository contents and (depending on whether it pushes to GHCR) likely `packages: write` to upload packages. To implement the fix, edit `.github/workflows/helm.yaml` by inserting a `permissions` block after the workflow `name:` and before the `on:` section, with the minimal necessary set: `contents: read` and `packages: write`. No extra methods or imports are needed—this is a YAML configuration fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
